### PR TITLE
Added parse functionality for LUMP_CUBEMAPS

### DIFF
--- a/luabsp.lua
+++ b/luabsp.lua
@@ -448,7 +448,16 @@ do
         [LUMP_CLIPPORTALVERTS] = -- Clipped portal polygon vertices
             function(fl, lump_data) end,
         [LUMP_CUBEMAPS] = -- env_cubemap location array
-            function(fl, lump_data) end,
+            function(fl, lump_data)
+                lump_data.data = {}
+                lump_data.size = lump_data.filelen / 16
+                for i=0, lump_data.size - 1 do
+                    lump_data.data[i] = {
+                        origin = Vector(fl:ReadLong(), fl:ReadLong(), fl:ReadLong()),
+						size = 2^(fl:ReadLong()-1)
+					}
+                end
+			end,
         [LUMP_TEXDATA_STRING_DATA] = -- Texture name data
             function(fl, lump_data)
                 lump_data.data = {}

--- a/luabsp.lua
+++ b/luabsp.lua
@@ -451,12 +451,13 @@ do
             function(fl, lump_data)
                 lump_data.data = {}
                 lump_data.size = lump_data.filelen / 16
-                local origin = Vector(fl:ReadLong(), fl:ReadLong(), fl:ReadLong())
-                local size = fl:ReadLong()
-
-                if size < 1 then size = 6 end -- default size should be 32x32
 
                 for i=0, lump_data.size - 1 do
+                    local origin = Vector(fl:ReadLong(), fl:ReadLong(), fl:ReadLong())
+                    local size = fl:ReadLong()
+    
+                    if size < 1 then size = 6 end -- default size should be 32x32
+
                     lump_data.data[i] = {
                         origin = origin,
                         size = 2^(size-1)

--- a/luabsp.lua
+++ b/luabsp.lua
@@ -451,13 +451,18 @@ do
             function(fl, lump_data)
                 lump_data.data = {}
                 lump_data.size = lump_data.filelen / 16
+                local origin = Vector(fl:ReadLong(), fl:ReadLong(), fl:ReadLong())
+                local size = fl:ReadLong()
+
+                if size < 1 then size = 6 end -- default size should be 32x32
+
                 for i=0, lump_data.size - 1 do
                     lump_data.data[i] = {
-                        origin = Vector(fl:ReadLong(), fl:ReadLong(), fl:ReadLong()),
-						size = 2^(fl:ReadLong()-1)
-					}
+                        origin = origin,
+                        size = 2^(size-1)
+                    }
                 end
-			end,
+            end,
         [LUMP_TEXDATA_STRING_DATA] = -- Texture name data
             function(fl, lump_data)
                 lump_data.data = {}


### PR DESCRIPTION
Stores origin and size of cubemaps from env_cubemap. Size is automatically converted to what it would say in hammer (ex. **64**x64) using the equation shown [here](https://developer.valvesoftware.com/wiki/Source_BSP_File_Format#Cubemap).

![image](https://user-images.githubusercontent.com/19823165/66257326-a952cd80-e765-11e9-8202-ab4d70b722a8.png)
